### PR TITLE
Enable to create exec only for web

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:latest
 COPY . $GOPATH/src/github.com/lccezinha/twodo
 WORKDIR $GOPATH/src/github.com/lccezinha/twodo
 
-# RUN go build -o `go env GOPATH`/bin/twodo .
-RUN go install
+RUN go build -o `go env GOPATH`/bin/twodo ./cmd/web
 
 CMD twodo
 

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 
@@ -11,9 +12,9 @@ func main() {
 	router := application.InitializeRouter()
 	port := ":8888"
 
+	fmt.Printf("Server running on port: %s\n", port)
 	err := http.ListenAndServe(port, router)
 	if err != nil {
 		log.Fatalf("Could not start server: %s\n", err.Error())
 	}
-	log.Printf("Server running in port: %s\n", port)
 }


### PR DESCRIPTION
As `cmd/web` folder contain a `main.go` file, it will allow to create diff "views" of this project. 

For example, if I had `cmd/cli` I can create all code related to cli presentation an create an executable file just for this version.